### PR TITLE
chore: Migrate the project to React Native `0.68.2`

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: "com.android.application"
 
 import com.android.build.OutputFile
+import org.apache.tools.ant.taskdefs.condition.Os
 
 /**
  * The react.gradle file registers a task for each build variant (e.g. bundleDebugJsAndAssets
@@ -157,6 +158,16 @@ android {
                     // Make sure this target name is the same you specify inside the
                     // src/main/jni/Android.mk file for the `LOCAL_MODULE` variable.
                     targets "timelessreactnativechallenge_appmodules"
+                    
+                    // Fix for windows limit on number of character in file paths and in command lines
+                    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                        arguments "NDK_APP_SHORT_COMMANDS=true"
+                    }
+                }
+            }
+            if (!enableSeparateBuildPerCPUArchitecture) {
+                ndk {
+                    abiFilters (*reactNativeArchitectures())
                 }
             }
         }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
@@ -6,7 +8,14 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 31
         targetSdkVersion = 31
-        ndkVersion = "21.4.7075529"
+
+        if (System.properties['os.arch'] == "aarch64") {
+            // For M1 Users we need to use the NDK 24 which added support for aarch64
+            ndkVersion = "24.0.8215888"
+        } else {
+            // Otherwise we default to the side-by-side NDK version from AGP.
+            ndkVersion = "21.4.7075529"
+        }
     }
     repositories {
         google()

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -5,4 +5,4 @@ includeBuild('../node_modules/react-native-gradle-plugin')
 if (settings.hasProperty("newArchEnabled") && settings.newArchEnabled == "true") {
     include(":ReactAndroid")
     project(":ReactAndroid").projectDir = file('../node_modules/react-native/ReactAndroid')
-}
+} 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@shopify/restyle": "^1.4.0",
     "react": "17.0.2",
-    "react-native": "0.68.0"
+    "react-native": "0.68.2"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
## chore: Migrate the project to React Native `0.68.2`

This follows the [migration guide - from 0.68.0 to 0.68.2](https://react-native-community.github.io/upgrade-helper/?from=0.68.0&to=0.68.2) . 

It was identified that the react-native types were incompartible with version `0.68.0`. Upgrading to the latest `0.68.2` solved the issues but required additional native changes for Android.
- Note: These fixes on android were mainly for `M1` Users we need to use the `NDK 24` which added support for `aarch64`.
- This also finalizes the upgrade to the most recent stable version of RN.